### PR TITLE
Fix `Asset` filter

### DIFF
--- a/tests/full/test_01_upload_bundles.py
+++ b/tests/full/test_01_upload_bundles.py
@@ -12,6 +12,7 @@ path_versions_1 = [
 
 path_versions_2 = [
     ("/api/v1/attack-enterprise/", "15_1"),
+    ("/api/v1/attack-ics/", "17_0"),
     ("/api/v1/cwe/", "4_15"),
     ("/api/v1/capec/", "3_8"),
     ("/api/v1/disarm/", "1_5"),

--- a/tests/full/test_04_filters_generic.py
+++ b/tests/full/test_04_filters_generic.py
@@ -336,6 +336,7 @@ def test_filter_type(client, path, types, expected_count):
         ["attack-enterprise", "Data Source", 37],
         ["attack-enterprise", "Data Component", 106],
         ["attack-enterprise", "Asset", 0],
+        ["attack-ics", "Asset", 14],
         ######### DISARM ###########
         ["disarm", "Tactic", 16],
         ["disarm", "Technique", 103],

--- a/tests/full/test_09_semantic_search.py
+++ b/tests/full/test_09_semantic_search.py
@@ -28,12 +28,14 @@ def test_search_with_types(client, types):
 @pytest.mark.parametrize(
     "knowledge_bases,expected_count",
     [
-        [[], 52],
-        [['attack-ics'], 0], #not ingested
+        [[], 60],
+        [['attack-ics'], 8],
+        [['attack-mobile'], 0], #not ingested
         [['attack-enterprise'], 13],
-        [['attack'], 13],
-        [['attack', 'attack-ics'], 13],
-        [['location', 'attack'], 13],
+        [['attack'], 21],
+        [['attack', 'attack-ics'], 21],
+        [['attack-ics', 'attack-mobile'], 8],
+        [['location', 'attack'], 21],
         [['location', 'cwe'], 7],
         [['capec'], 25],
         [['disarm'], 7],
@@ -63,22 +65,21 @@ def test_search_with_show_knowledgebase(client):
 @pytest.mark.parametrize(
     ['filters', 'count'],
     [
-        pytest.param(dict(include_deprecated=False, include_revoked=False), 52, id='exclude-both-explicit'),
-        pytest.param(dict(), 52, id='exclude-both-implicit'),
-        pytest.param(dict(include_deprecated=True, include_revoked=False), 54, id='include-deprecated-explicit'),
-        pytest.param(dict(include_deprecated=True), 54, id='exclude-revoked-implicit'),
-        pytest.param(dict(include_deprecated=False, include_revoked=True), 56, id='include-revoked-explicit'),
-        pytest.param(dict(include_revoked=True), 56, id='exlude-deprecated-implicit'),
-        pytest.param(dict(include_deprecated=True, include_revoked=True), 58, id='include-both-explicit'),
-        pytest.param(dict(types='attack-pattern', knowledge_base='capec'), 32, id='capec-implicit-exclude-deprecated'),
-        pytest.param(dict(types='attack-pattern', knowledge_base='capec', include_deprecated=False), 32, id='capec-explicit-exclude-deprecated'),
-        pytest.param(dict(types='attack-pattern', knowledge_base='capec', include_deprecated=True), 34, id='capec-explicit-include-deprecated'),
+        pytest.param(dict(include_deprecated=False, include_revoked=False), 5752, id='exclude-both-explicit'),
+        pytest.param(dict(), 5752, id='exclude-both-implicit'),
+        pytest.param(dict(include_deprecated=True, include_revoked=False), 6098, id='include-deprecated-explicit'),
+        pytest.param(dict(include_deprecated=True), 6098, id='exclude-revoked-implicit'),
+        pytest.param(dict(include_deprecated=False, include_revoked=True), 5918, id='include-revoked-explicit'),
+        pytest.param(dict(include_revoked=True), 5918, id='exlude-deprecated-implicit'),
+        pytest.param(dict(include_deprecated=True, include_revoked=True), 6264, id='include-both-explicit'),
+        pytest.param(dict(knowledge_bases='capec'), 1453, id='capec-implicit-exclude-deprecated'),
+        pytest.param(dict(knowledge_bases='capec', include_deprecated=False), 1453, id='capec-exclude-deprecated-explicit'),
+        pytest.param(dict(knowledge_bases='capec', include_deprecated=True), 1510, id='capec-include-deprecated-explicit'),
     ]
 )
 def test_include_revoked_and_include_deprecated(client, filters, count):
-    params = {'text': 'deny'}
+    params = {}
     params.update(filters)
-
     resp = client.get("/api/v1/search/", query_params=params)
     assert resp.status_code == 200
     assert resp.data['total_results_count'] == count


### PR DESCRIPTION
closes #186 
- fix [failing tests](https://github.com/muchdogesec/ctibutler/actions/runs/16936768829/job/47995125312#step:7:197)
- Fix `attack_type=Asset` filter
- import attack ics while testing, so `attack_type=Asset` filter is tested (this has to be done because `mitre enterprise` doesn't carry assets)